### PR TITLE
Added html headers for *.html endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ http://localhost:8080/form?from=10&to=100
 shell2http -output -form /form 'echo $v_from, $v_to'
 ```
 
+html sufix to endpoint will change header to "text/html":
+```bash
+# Ability to have server events and server simple html pages as clients
+shell2http -output -sse /serve_files_as.html "cat LICENSE|sed 's/.*/<pre>&<\/pre>/'"
+```
+
 # Acknowledgements
 
 https://github.com/msoap/shell2http

--- a/shell2http.py
+++ b/shell2http.py
@@ -20,7 +20,10 @@ def shellHTTPRequestHandler(args):
         def do_GET(self):
             self.send_response(200)
             parsed_url = urlparse(self.path)
-            if args.sse:
+
+            if parsed_url.path.endswith("html"):
+                self.send_header('Content-Type', 'text/html')
+            elif args.sse:
                 self.send_header('Content-Type', 'text/event-stream')
                 args.output = True
             self.end_headers()


### PR DESCRIPTION
Sometime there is need to have simple html pages to render the out put of commands(e.g. with -sse option). Proposal here is have naming convention that if endpoint ends with *.html prefix send proper header. in this way it could be severed html files with something like this:  ```shell2http -output -sse /my_client.html "cat my_client.html"```